### PR TITLE
Add GitHub Actions CI, Docker publish workflow, and README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,136 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build and Test (${{ matrix.service }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - api-gateway
+          - naming-server
+          - template-service
+          - user-service
+    defaults:
+      run:
+        working-directory: ${{ matrix.service }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Build and run tests
+        run: mvn -B -ntp verify
+
+  compose-smoke-test:
+    name: Compose Smoke Test
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Package service jars
+        run: |
+          set -euo pipefail
+          (cd naming-server && mvn -B -ntp -DskipTests package)
+          (cd user-service && mvn -B -ntp -DskipTests package)
+          (cd template-service && mvn -B -ntp -DskipTests package)
+          (cd api-gateway && mvn -B -ntp -DskipTests package)
+
+      - name: Start Docker Compose stack
+        run: docker compose up -d --build
+
+      - name: Wait for containers to become healthy/running
+        run: |
+          set -euo pipefail
+          deadline=$((SECONDS + 300))
+
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            mysql_health=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' starterkit-mysql || true)
+            naming_status=$(docker inspect -f '{{.State.Status}}' starterkit-naming-server || true)
+            user_status=$(docker inspect -f '{{.State.Status}}' starterkit-user-service || true)
+            template_status=$(docker inspect -f '{{.State.Status}}' starterkit-template-service || true)
+            gateway_status=$(docker inspect -f '{{.State.Status}}' starterkit-api-gateway || true)
+
+            if [ "$mysql_health" = "healthy" ] && \
+               [ "$naming_status" = "running" ] && \
+               [ "$user_status" = "running" ] && \
+               [ "$template_status" = "running" ] && \
+               [ "$gateway_status" = "running" ]; then
+              echo "All services are running and healthy."
+              break
+            fi
+
+            if [ "$naming_status" = "exited" ] || [ "$naming_status" = "restarting" ] || \
+               [ "$user_status" = "exited" ] || [ "$user_status" = "restarting" ] || \
+               [ "$template_status" = "exited" ] || [ "$template_status" = "restarting" ] || \
+               [ "$gateway_status" = "exited" ] || [ "$gateway_status" = "restarting" ]; then
+              echo "A service exited or is restarting unexpectedly."
+              docker compose ps
+              docker compose logs --tail=200
+              exit 1
+            fi
+
+            sleep 5
+          done
+
+          if [ "$SECONDS" -ge "$deadline" ]; then
+            echo "Timeout waiting for Compose services to be healthy."
+            docker compose ps
+            docker compose logs --tail=200
+            exit 1
+          fi
+
+      - name: Basic endpoint checks
+        run: |
+          set -euo pipefail
+          curl --retry 20 --retry-delay 3 --retry-all-errors -fsS http://localhost:18761 > /dev/null
+          gateway_code=$(curl -sS -o /dev/null -w '%{http_code}' http://localhost:18765/)
+          if [ "$gateway_code" = "000" ]; then
+            echo "API Gateway is not reachable."
+            exit 1
+          fi
+
+      - name: Show compose status
+        if: always()
+        run: docker compose ps
+
+      - name: Show recent logs on failure
+        if: failure()
+        run: docker compose logs --tail=300
+
+      - name: Stop Docker Compose stack
+        if: always()
+        run: docker compose down -v

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,83 @@
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Docker image tag to publish
+        required: false
+        default: latest
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build and Push Multi-Arch Images
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Package service jars
+        run: |
+          set -euo pipefail
+          (cd naming-server && mvn -B -ntp -DskipTests package)
+          (cd user-service && mvn -B -ntp -DskipTests package)
+          (cd template-service && mvn -B -ntp -DskipTests package)
+          (cd api-gateway && mvn -B -ntp -DskipTests package)
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Resolve image tag
+        id: resolve-tag
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            TAG="${GITHUB_REF_NAME}"
+          else
+            TAG="${{ github.event.inputs.image_tag }}"
+          fi
+
+          if [ -z "$TAG" ]; then
+            TAG="latest"
+          fi
+
+          echo "image_tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Docker Hub secrets
+        run: |
+          if [ -z "${{ secrets.DOCKERHUB_USERNAME }}" ] || [ -z "${{ secrets.DOCKERHUB_TOKEN }}" ]; then
+            echo "Missing required secrets: DOCKERHUB_USERNAME and/or DOCKERHUB_TOKEN"
+            exit 1
+          fi
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push images
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          IMAGE_TAG: ${{ steps.resolve-tag.outputs.image_tag }}
+        run: ./scripts/build-and-push-images.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Spring Boot Microservices Starter Kit
 
+[![CI](https://github.com/slubambo/SpringBoot-Microservices-StarterKit/actions/workflows/ci.yml/badge.svg)](https://github.com/slubambo/SpringBoot-Microservices-StarterKit/actions/workflows/ci.yml)
+[![Docker Publish](https://github.com/slubambo/SpringBoot-Microservices-StarterKit/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/slubambo/SpringBoot-Microservices-StarterKit/actions/workflows/docker-publish.yml)
+
 A practical starter kit for building Spring Boot microservices with service discovery, gateway routing, JWT authentication, and inter-service communication.
 
 This project is designed for two outcomes:
@@ -31,6 +34,17 @@ This project is designed for two outcomes:
 3. Client calls secured routes through `api-gateway`.
 4. Gateway validates token and forwards user context to downstream services.
 5. Services discover each other through `naming-server`.
+
+## CI and Automation
+
+- `CI` workflow runs on pull requests to `main`, pushes to `main`, and manual dispatch.
+- CI validates each service with Maven `verify` and runs a Docker Compose smoke test for the full stack.
+- `Docker Publish` workflow runs only on version tags (`v*`) or manual dispatch.
+- Merging to `main` does not push images to Docker Hub by default.
+
+Required GitHub repository secrets for image publishing:
+- `DOCKERHUB_USERNAME`
+- `DOCKERHUB_TOKEN`
 
 ## Quick Start (Docker Compose)
 
@@ -123,15 +137,22 @@ Key values:
 
 ## Docker image publishing (multi-arch)
 
+### Option A: GitHub Actions publish
+
+- On release tag push (for example `v1.0.0`), GitHub Actions builds and publishes multi-arch images.
+- You can also trigger publish manually from the `Docker Publish` workflow and provide a custom tag.
+
+### Option B: Local manual publish
+
 This repo includes `scripts/build-and-push-images.sh`, which follows your `buildx` approach and pushes all 4 service images.
 
-### 1. Login to Docker Hub
+1. Login to Docker Hub
 
 ```bash
 docker login
 ```
 
-### 2. Build and push
+2. Build and push
 
 ```bash
 DOCKERHUB_USERNAME=slubambo IMAGE_TAG=latest ./scripts/build-and-push-images.sh


### PR DESCRIPTION
## Summary
- add CI workflow for PR/main with service build-test matrix and compose smoke test
- add Docker publish workflow for Docker Hub (multi-arch) on version tags and manual runs
- add README badges and clear CI/CD behavior documentation

## Important Behavior
- merge to `main` runs CI checks
- Docker Hub publish is **not** triggered by merge to `main`
- Docker Hub publish runs only on `v*` tags or manual workflow dispatch

## Required GitHub Secrets
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN`